### PR TITLE
Issue-8: Install Fork of dopy Which Supports Getting Droplets by Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ I am receptive to suggestions and happy to accept pull requests. However, for pu
   * dopy
   * python-digitalocean
   * supervisor
+  * unzip
+  * dopy
 
 * A generic user, "droplet-user"
   * member of sudo users

--- a/ansible-base/install.yml
+++ b/ansible-base/install.yml
@@ -10,6 +10,7 @@
           - ntp
           - iptables-persistent
           - dnsmasq
+          - unzip
 
       - name: Install python modules
         pip:

--- a/ansible-base/roles/base-install/tasks/install_dopy_fork.yml
+++ b/ansible-base/roles/base-install/tasks/install_dopy_fork.yml
@@ -1,0 +1,9 @@
+---
+- name: Download dopy fork source
+  get_url: url=https://github.com/mjtieman/dopy/archive/master.zip dest=/home/droplet-user owner=droplet-user group=droplet-user mode=0755
+
+- name: Unzip the dopy source
+  unarchive: src=/home/droplet-user/dopy-master.zip dest=/home/droplet-user remote_src=yes
+
+- name: Install dopy from source
+  shell: python setup.py install chdir=/home/droplet-user/dopy-master

--- a/ansible-base/roles/base-install/tasks/main.yml
+++ b/ansible-base/roles/base-install/tasks/main.yml
@@ -5,6 +5,9 @@
 - name: Copy the script to get the account SSH public key
   copy: src=get_public_key.py dest=/etc/common/config owner=droplet-user group=droplet-user mode=0755
 
+- name: Install dopy fork supporting tag-based discovery from source
+  include: install_dopy_fork.yml
+
 - name: Add the SSH public key to droplet-user
   include: add_public_key.yml
 


### PR DESCRIPTION
Changes for issue #8. Install the mjtieman fork of [dopy](https://github.com/mjtieman/dopy) which supports retrieving droplets by tag-name. Required installing unzip.
