### PR TITLE
Issue-14: Upgrade Ansible to 2.2.0

### DIFF
--- a/packer/base.json
+++ b/packer/base.json
@@ -16,7 +16,8 @@
         "region" : "{{ user `region` }}",
         "size" : "512mb",
         "private_networking" : true,
-        "snapshot_name" : "{{ user `base-snapshot-name` }}-{{user `version`}}-{{isotime}}"
+        "snapshot_name" : "{{ user `base-snapshot-name` }}-{{user `version`}}-{{isotime}}",
+        "ssh_username" : "root"
     }],
     "provisioners" : [
         {

--- a/packer/packer.sh
+++ b/packer/packer.sh
@@ -8,7 +8,7 @@ sudo apt-get install libpython-all-dev -y
 sudo apt-get install python-pip -y
 
 sudo pip install markupsafe # Not included in jinja dependencies, need to install ourselves
-sudo pip install ansible==2.1.0
+sudo pip install ansible==2.2.0
 
 # Create a generic user for the droplet
 sudo apt-get install whois


### PR DESCRIPTION
Upgraded ansible to 2.2.0. Added root ssh_username to builder, needed after upgrading packer to 0.12.1. #14 .